### PR TITLE
Directory javafx

### DIFF
--- a/tutoring_room/src/main/java/brogrammers/tutoring_room/App.java
+++ b/tutoring_room/src/main/java/brogrammers/tutoring_room/App.java
@@ -13,6 +13,7 @@ public class App extends Application {
     public void start(Stage stage) {
 
     	SceneSwitcher switcher = new SceneSwitcher(stage);
+    	switcher.makeRooms();
    
     	stage.setScene(switcher.LoginScene());
     	stage.centerOnScreen();

--- a/tutoring_room/src/main/java/brogrammers/tutoring_room/DirectoryView.java
+++ b/tutoring_room/src/main/java/brogrammers/tutoring_room/DirectoryView.java
@@ -22,8 +22,8 @@ public class DirectoryView extends Pane{
 	private Stage stage;
 	private SceneSwitcher switcher;
 	
-	// ArrayList for storing and accessing separate rooms
-	public ArrayList<VBox> rooms;
+	// ArrayList for storing and accessing room VBoxes
+	private ArrayList<VBox> roomVBoxes;
 	
 	// Labels
 	private Label titleLabel;
@@ -43,12 +43,12 @@ public class DirectoryView extends Pane{
 	private VBox directoryBox;
 	
 	
-	public DirectoryView(Stage stage)
+	public DirectoryView(Stage stage, SceneSwitcher switcher)
 	{
 		this.stage = stage;
-		this.switcher = new SceneSwitcher(stage);
+		this.switcher = switcher;
 
-		this.rooms = new ArrayList<VBox>();
+		this.roomVBoxes = new ArrayList<VBox>();
 		
 		initializeVariables();
 		stylizeElements();
@@ -102,12 +102,12 @@ public class DirectoryView extends Pane{
 			buildRoom(i);
 		}
 		
-		roomsGrid.add(rooms.get(0), 0, 0);
-		roomsGrid.add(rooms.get(1), 1, 0);
-		roomsGrid.add(rooms.get(2), 2, 0);
-		roomsGrid.add(rooms.get(3), 0, 1);
-		roomsGrid.add(rooms.get(4), 1, 1);
-		roomsGrid.add(rooms.get(5), 2, 1);
+		roomsGrid.add(roomVBoxes.get(0), 0, 0);
+		roomsGrid.add(roomVBoxes.get(1), 1, 0);
+		roomsGrid.add(roomVBoxes.get(2), 2, 0);
+		roomsGrid.add(roomVBoxes.get(3), 0, 1);
+		roomsGrid.add(roomVBoxes.get(4), 1, 1);
+		roomsGrid.add(roomVBoxes.get(5), 2, 1);
 		
 		directoryBox.getChildren().addAll(headerRow, roomsGrid);
 		
@@ -154,7 +154,7 @@ public class DirectoryView extends Pane{
 		Button roomButton = new Button("Join");
 		HBox.setMargin(roomButton, new Insets(10, 10, 10, 0));
 		// TO-DO: Switch to unique room scenes
-		roomButton.setOnAction(e -> stage.setScene(switcher.RoomScene()));
+		roomButton.setOnAction(e -> stage.setScene(switcher.RoomScene(roomNum)));
 		
 		HBox roomHeaderBox = new HBox();
 		roomHeaderBox.setPrefSize(333.3, 20);
@@ -214,6 +214,6 @@ public class DirectoryView extends Pane{
 		
 		roomBox.getChildren().addAll(roomHeaderBox, statusRow, tutorRow, coursesRow, studentsRow);
 		
-		rooms.add(roomBox);
+		roomVBoxes.add(roomBox);
 	}
 }

--- a/tutoring_room/src/main/java/brogrammers/tutoring_room/LoginView.java
+++ b/tutoring_room/src/main/java/brogrammers/tutoring_room/LoginView.java
@@ -43,10 +43,10 @@ public class LoginView extends Pane{
 	private VBox selectionBox;
 	private VBox loginBox;
 	
-	public LoginView(Stage stage)
+	public LoginView(Stage stage, SceneSwitcher switcher)
 	{
 		this.stage = stage;
-		this.switcher = new SceneSwitcher(stage);
+		this.switcher = switcher;
 
 		initializeVariables();
 		stylizeElements();
@@ -116,7 +116,7 @@ public class LoginView extends Pane{
 	public void assignSetOnActions()
 	{
 		signInButton.setOnAction(e -> stage.setScene(switcher.DirectoryScene()));
-		// rooms array is public to be used here to set the label texts
+		// rooms array from SceneSwitcher is public to be used here to set the label texts
 	}
 	
 	public void populateChildren() 

--- a/tutoring_room/src/main/java/brogrammers/tutoring_room/RoomView.java
+++ b/tutoring_room/src/main/java/brogrammers/tutoring_room/RoomView.java
@@ -48,10 +48,10 @@ public class RoomView extends Pane{
 	
 	//Image raiseHandIcon;
 	
-	public RoomView(Stage stage)
+	public RoomView(Stage stage, SceneSwitcher switcher)
 	{
 		this.stage = stage;
-		this.switcher = new SceneSwitcher(stage);
+		this.switcher = switcher;
 
 		initializeVariables();
 		stylizeElements();

--- a/tutoring_room/src/main/java/brogrammers/tutoring_room/SceneSwitcher.java
+++ b/tutoring_room/src/main/java/brogrammers/tutoring_room/SceneSwitcher.java
@@ -1,5 +1,7 @@
 package brogrammers.tutoring_room;
 
+import java.util.ArrayList;
+
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.layout.HBox;
@@ -8,15 +10,25 @@ import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
 public class SceneSwitcher extends Pane{
-	Stage stage;
+	private Stage stage;
+	
+	public ArrayList<RoomView> rooms;
 	
 	public SceneSwitcher(Stage stage) {
 		this.stage = stage;
+		rooms = new ArrayList<RoomView>();
+	}
+	
+	public void makeRooms() {
+		for(int i = 0; i < 6; i++) {
+			RoomView roomView = new RoomView(stage, this);
+			rooms.add(roomView);
+		}
 	}
 	
 	public Scene LoginScene() {
 		HBox loginBox = new HBox();
-    	LoginView loginView = new LoginView(this.stage);
+    	LoginView loginView = new LoginView(this.stage, this);
     	stage.setTitle("Sign in");
     	
     	loginBox.setAlignment(Pos.CENTER);
@@ -30,7 +42,7 @@ public class SceneSwitcher extends Pane{
 
 	public Scene DirectoryScene() {
 		VBox directoryVBox = new VBox();
-		DirectoryView directoryView = new DirectoryView(this.stage);
+		DirectoryView directoryView = new DirectoryView(this.stage, this);
 
 		directoryVBox.setAlignment(Pos.TOP_LEFT);
 		directoryVBox.getChildren().add(directoryView);
@@ -42,12 +54,12 @@ public class SceneSwitcher extends Pane{
         return directoryScene;
 	}
 	
-	public Scene RoomScene() {
+	public Scene RoomScene(int roomNum) {
+		System.out.println("Switching to room " + roomNum);
 		VBox roomVBox = new VBox();
-		RoomView roomView = new RoomView(this.stage);
 
 		roomVBox.setAlignment(Pos.TOP_LEFT);
-		roomVBox.getChildren().add(roomView);
+		roomVBox.getChildren().add(rooms.get(roomNum - 1));
         Scene roomScene = new Scene(roomVBox, 1000, 600);
         stage.setTitle("Virtual Tutoring");
         


### PR DESCRIPTION
Implemented unique rooms. Each "Join" button on directory scene goes to the appropriate Room created at the beginning of the code. I found a bug where we were making a new SceneSwitcher object instead of referencing the one made in the beginning so that is fixed. It was causing an issue with trying to reference the rooms ArrayList because only the original SceneSwitcher object had made the rooms with makeRooms() function in main.  